### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,10 @@
 
 name: Auto-Merge Dependabot PRs
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   # WARNING: This needs to be run in the PR base, DO NOT build untrusted code in this action
   # details under https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/


### PR DESCRIPTION
Potential fix for [https://github.com/eifel-tech/ioBroker.cloudless-homeconnect/security/code-scanning/7](https://github.com/eifel-tech/ioBroker.cloudless-homeconnect/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's functionality:
- It checks out code, which requires `contents: read`.
- It interacts with pull requests, which requires `pull-requests: write`.

The `permissions` block should be added at the workflow level (root) to apply to all jobs, as there is only one job (`auto-merge`) in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
